### PR TITLE
fix: adjusting font import and font styles in CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,9 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@700&family=Montserrat&display=swap');
 
 :root {
   --var-color: #000084;
-  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@700&family=Montserrat&display=swap" rel="stylesheet" type="text/css"></link>
-
 }
+
 @media(max-width:800px){
   :root{
     background:#ECFFA1;
@@ -13,7 +13,7 @@
 
 .container-class {
   margin: 40px 80px 40px 80px;
-  font-family: Montserrat;
+  font-family: 'Montserrat', sans-serif;
 }
 
 p {
@@ -26,12 +26,12 @@ p {
 .title-style {
   color: #071541;
   font-size: 48px;
-  font-family: Lato;
+  font-family: 'Lato', sans-serif;
 }
 
 h3 {
   color: var(--var-color, green);
-  font-family: Lato;
+  font-family: 'Lato', sans-serif;
   font-size: 24px;
   text-transform: capitalize;
   font-weight: 800;


### PR DESCRIPTION
This pull request includes changes to the `css/style.css` file to improve font usage. The most important changes are as follows:

Font usage improvements:

* Replaced the `<link>` HTML tag with an `@import` statement for Google Fonts at the top of the `css/style.css` file.
* Updated the `font-family` property for `.container-class` to use `'Montserrat', sans-serif`.
* Updated the `font-family` property for `.title-style` and `h3` elements to use `'Lato', sans-serif`.

Tnx for your review! 😊